### PR TITLE
Fix Conda-based CI on a self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-version: latest
-          #activate-environment: ${GITHUB_WORKSPACE}/whatever
-          #remove-profiles: false
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-version: latest
+          #miniforge-version: latest
           activate-environment: ${GITHUB_WORKSPACE}/whatever
           remove-profiles: false
       - name: Conda info
         shell: bash -l {0}
         run: conda info
       - name: Conda list
-        shell: pwsh
+        shell: bash -l {0}
         run: conda list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: whatever
+          activate-environment: ${GITHUB_WORKSPACE}/whatever
           auto-update-conda: true
       - name: Conda info
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [self-hosted]
-        python-version: ["3.7", "2.7"]
+        python-version: ["3.7"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-activate-base: true
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
       - name: Conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [self-hosted]
+        os: [ubuntu-latest, self-hosted]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-activate-base: true
-          activate-environment: ""
+          activate-environment: whatever
           auto-update-conda: true
       - name: Conda info
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,9 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-version: latest
           activate-environment: ${GITHUB_WORKSPACE}/whatever
-          auto-update-conda: true
+          remove-profiles: false
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           miniforge-version: latest
           activate-environment: ${GITHUB_WORKSPACE}/whatever
-          remove-profiles: false
+          #remove-profiles: false
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          #miniforge-version: latest
+          miniforge-version: latest
           activate-environment: ${GITHUB_WORKSPACE}/whatever
           remove-profiles: false
       - name: Conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-activate-base: true
+          activate-environment: ""
           auto-update-conda: true
           python-version: ${{ matrix.python-version }}
       - name: Conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-version: latest
-          activate-environment: ${GITHUB_WORKSPACE}/whatever
+          #activate-environment: ${GITHUB_WORKSPACE}/whatever
           #remove-profiles: false
       - name: Conda info
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,20 +4,18 @@ on: [push]
 
 jobs:
   example-1:
-    name: Ex1 (${{ matrix.python-version }}, ${{ matrix.os }})
+    name: Ex1 (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [self-hosted]
-        python-version: ["2.7"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-activate-base: true
           activate-environment: ""
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
       - name: Conda info
         shell: bash -l {0}
         run: conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [self-hosted]
-        python-version: ["3.7"]
+        python-version: ["2.7"]
     steps:
       - uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
With this status the Conda-based CI goes through with no errors.

I have to put `miniforge-version: latest` for the self-hosted runner to work.